### PR TITLE
fix: formatting of escape sequence examples

### DIFF
--- a/guide/english/python/escape-sequences/index.md
+++ b/guide/english/python/escape-sequences/index.md
@@ -25,11 +25,14 @@ A _raw_ string can be used by prefixing the string with `r` or `R` which allows 
         print(r"An odd number of backslashes at the end of a raw string will cause an error\")
                                                                                              ^
     SyntaxError: EOL while scanning string literal.
- #Some more examples of escape sequences.
- Escape Sequence	
-\\ 	Prints Backslash 	
-\` 	Prints single-quote 	
-\" 	Prints double quote 	
-\a 	ASCII bell makes ringing the bell alert sounds ( eg. xterm ) 
-\b 	ASCII backspace ( BS ) removes previous character 
-\n  Adds newline.
+
+## Some more examples of escape sequences.
+
+Escape Sequence	<- Intended Character
+- \\\ 	<- backslash
+- \\' 	<- single quote / apostrophe	
+- \\" 	<- double quote / quotation mark	
+- \\a 	<- ASCII bell makes ringing the bell alert sounds ( eg. xterm ) 
+- \\b 	<- ASCII backspace ( BS ) removes previous character 
+- \\n   <- newline
+- \\r   <- carriage return


### PR DESCRIPTION
The formatting was a bit jumbled, so I cleaned up the formatting of the escape sequence.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

Closes #XXXXX
